### PR TITLE
Add project root option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export interface PluginOptions {
   title: string
   ignoreCoveragePattern: string[]
   coverageFilesPath: string
+  projectRoot?: string
 }
 
 export const defaultPluginOptions: PluginOptions[] = [

--- a/src/services/getCoverageForFile.ts
+++ b/src/services/getCoverageForFile.ts
@@ -5,7 +5,8 @@ import { PluginOptions } from ".."
 
 const rootDir = process.cwd()
 
-const getFileAbsolutePath = (filePath: string): string => path.join(rootDir, filePath)
+const getFileAbsolutePath = (filePath: string, projectRoot?: string): string =>
+  path.join(projectRoot || rootDir, filePath);
 
 export const getCoverageForFile = (filePath: string, options?: PluginOptions) => {
   const coverageFilePath = getFileAbsolutePath((options && options.coverageFilesPath) || "coverage/coverage-final.json")
@@ -16,5 +17,5 @@ export const getCoverageForFile = (filePath: string, options?: PluginOptions) =>
 
   const coverageByPath = keyBy(coverages, (coverage: { path: string }) => coverage.path)
 
-  return coverageByPath[getFileAbsolutePath(filePath)]
+  return coverageByPath[getFileAbsolutePath(filePath, options && options.projectRoot)]
 }


### PR DESCRIPTION
When the frontend app is in a different directory than the project root the file paths used to fetch the test coverage from the path => coverage map gets constructed in correctly. By allowing the user to pass in a projectRoot parameter the plugin is able to support any app directory structure.

As an example my folder structure is
`~/App/frontend`
The previous behavior would create a file path of `~/App/frontend/frontend/foo`, when the path is `~/App/frontend/foo`
By passing in a rootDir of `..` the issue is fixed.

I went ahead and made it an optional param so it doesnt break anyone elses workflow