### PR TITLE
Updated title to have space before #

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export function codeCoverage(pluginOptions: PluginOptions[] = defaultPluginOptio
         .concat([[], [":pencil2: **MODIFIED FILES**"], []])
         .concat(generateCoverageTable(danger.git.modified_files.filter(filterFiles), options))
 
-      markdown(`#${options.title}\n${generateMarkdownTable(coverageTable)}`)
+      markdown(`# ${options.title}\n${generateMarkdownTable(coverageTable)}`)
     } catch (error) {
       fail(`An error occurred when getting the code coverage: ${error.message}. Danger exits with code: ${error.code}`)
     }


### PR DESCRIPTION
On Github, you need to have a space before the hashtag or the title does not render:

#title `#title`

vs.

# title `# title`